### PR TITLE
Add go.mod, remove smurf naming, improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-graphite-client [![Build Status](https://travis-ci.org/jtaczanowski/go-graphite-client.png?branch=master)](https://travis-ci.org/jtaczanowski/go-graphite-client) [![Coverage Status](https://coveralls.io/repos/github/jtaczanowski/go-graphite-client/badge.svg?branch=master)](https://coveralls.io/github/jtaczanowski/go-graphite-client?branch=master)
 go-graphite-client - Simple Golang graphite client.
 
-Example usage (also included in example catalog)
+Example usage (also present in `example_text.go`)
 ```go
 package main
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Example usage (also included in example catalog)
 ```go
 package main
 
-import graphite "github.com/jtaczanowski/go-graphite-client"
+import (
+	"log"
+
+	graphite "github.com/jtaczanowski/go-graphite-client"
+)
 
 func main() {
 	graphiteClient := graphite.NewGraphiteClient("localhost", 2003, "metrics.prefix", "tcp")
@@ -17,6 +21,8 @@ func main() {
 	metricsToSend := []map[string]float64{exampleMetric1, exampleMetric2}
 
 	// graphiteClient.SendData(data []map[string]float64) error - this method receives a list of metrics as an argument
-	graphiteClient.SendData(metricsToSend)
+	if err := graphiteClient.SendData(metricsToSend); err != nil {
+		log.Printf("Error sending metrics: %v", err)
+	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	graphiteClient := graphite.NewGraphiteClient("localhost", 2003, "metrics.prefix", "tcp")
+	graphiteClient := graphite.NewClient("localhost", 2003, "metrics.prefix", "tcp")
 
 	// metrics
 	exampleMetric1 := map[string]float64{"test_metric": 1234.1234}

--- a/example_test.go
+++ b/example_test.go
@@ -1,9 +1,13 @@
 package main
 
-import graphite "github.com/jtaczanowski/go-graphite-client"
+import (
+	"log"
 
-func main() {
-	graphiteClient := graphite.NewGraphiteClient("localhost", 2003, "prefix", "tcp")
+	"github.com/jtaczanowski/go-graphite-client"
+)
+
+func Example() {
+	graphiteClient := graphite.NewClient("localhost", 2003, "metrics.prefix", "tcp")
 
 	// metrics
 	exampleMetric1 := map[string]float64{"test_metric": 1234.1234}
@@ -12,5 +16,7 @@ func main() {
 	metricsToSend := []map[string]float64{exampleMetric1, exampleMetric2}
 
 	// graphiteClient.SendData(data []map[string]float64) error - this method receives a list of metrics as an argument
-	graphiteClient.SendData(metricsToSend)
+	if err := graphiteClient.SendData(metricsToSend); err != nil {
+		log.Printf("Error sending metrics: %v", err)
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-package main
+package graphite_test
 
 import (
 	"log"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jtaczanowski/go-graphite-client
+
+go 1.13

--- a/graphite.go
+++ b/graphite.go
@@ -10,17 +10,17 @@ import (
 
 var timeNow = time.Now
 
-// GraphiteClient - struct with graphite connection settings
-type GraphiteClient struct {
+// Client - struct with Graphite connection settings
+type Client struct {
 	host     string
 	port     int
 	prefix   string
 	protocol string
 }
 
-// NewGraphiteClient - returns new NewGraphiteClient
-func NewGraphiteClient(Host string, Port int, Prefix string, Protocol string) *GraphiteClient {
-	return &GraphiteClient{
+// NewClient - returns new Client
+func NewClient(Host string, Port int, Prefix string, Protocol string) *Client {
+	return &Client{
 		host:     Host,
 		port:     Port,
 		prefix:   Prefix,
@@ -28,23 +28,24 @@ func NewGraphiteClient(Host string, Port int, Prefix string, Protocol string) *G
 	}
 }
 
-// SentData - pushes data to graphite server. Default connect timeout is set to 3s
-// SentData receives as argument []map[string]int64 where string is metric name, float64 is metric value
-// example: map[string]float64{"test": 1234.1234}
-func (g *GraphiteClient) SendData(data []map[string]float64) error {
-	dataToSent := g.prepareGraphiteData(data)
+// SentData - pushes data to Graphite server. Default connect timeout is set to 3s
+//
+// SentData receives as argument []map[string]int64 where string is metric name, float64 is metric value, example:
+//   map[string]float64{"test": 1234.1234}
+func (g *Client) SendData(data []map[string]float64) error {
+	dataToSent := g.prepareData(data)
 	conn, err := net.DialTimeout(g.protocol, g.host+":"+strconv.Itoa(g.port), time.Second*3)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 	for _, str := range dataToSent {
-		conn.Write([]byte(str))
+		_, _ = conn.Write([]byte(str))
 	}
 	return nil
 }
 
-func (g *GraphiteClient) prepareGraphiteData(data []map[string]float64) []string {
+func (g *Client) prepareData(data []map[string]float64) []string {
 	dataToGraphite := make([]string, 0)
 	for _, metric := range data {
 		for metricName, metricVal := range metric {

--- a/graphite.go
+++ b/graphite.go
@@ -1,3 +1,4 @@
+// Simple Graphite client
 package graphite
 
 import (

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -29,7 +29,7 @@ func TestSentMetricsOverTCP(t *testing.T) {
 	}()
 
 	// start tcp server
-	listener, err := net.Listen("tcp", ":2003")
+	listener, err := net.Listen("tcp", "localhost:2003")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -20,7 +20,7 @@ func TestSentMetricsOverTCP(t *testing.T) {
 
 	// create graphite client and sent metrics in separate gorutine
 	go func() {
-		graphiteClient := NewGraphiteClient("localhost", 2003, "prefix", "tcp")
+		graphiteClient := NewClient("localhost", 2003, "prefix", "tcp")
 		listMetrics := make([]map[string]float64, 0)
 
 		listMetrics = append(listMetrics, map[string]float64{"test": 1234.1234})
@@ -78,7 +78,7 @@ func TestSentMetricsOverUDP(t *testing.T) {
 	}()
 
 	// create graphite Client and sent two metrics
-	graphiteClient := NewGraphiteClient("localhost", 2003, "prefix", "udp")
+	graphiteClient := NewClient("localhost", 2003, "prefix", "udp")
 	listMetrics := make([]map[string]float64, 0)
 	listMetrics = append(listMetrics, map[string]float64{"test": 1234.1234})
 	listMetrics = append(listMetrics, map[string]float64{"test2": 12345.12345})


### PR DESCRIPTION
Hello @jtaczanowski,

This PR:
1. Adds [go.mod](https://blog.golang.org/using-go-modules) file;
1. Remove `graphite` from all functions and variables names, as the module is already named `graphite` which results in the so-called [Smurf naming](https://blog.codinghorror.com/new-programming-jargon/), where instead of `graphite.NewClient()` we call `graphite.NewGraphiteClient()`;
1. Explicitly ignore `conn.Write` errors;
1. Improve example by including error logging, as the current version recommended ignoring it;
1. Improve documentation and example formatting in it, [before](https://user-images.githubusercontent.com/712534/67642732-09750380-f90f-11e9-9a6b-60e6c95fe393.png) and [after](https://user-images.githubusercontent.com/712534/67642731-09750380-f90f-11e9-827d-7f621105e033.png);
1. Switch test to use `localhost:2003` instead of `:2003` which mean `0.0.0.0:2003` which triggers Apple firewall on `go test ./...`:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/712534/67642827-0d555580-f910-11e9-973c-e352b3cc4f13.png">


My apologies for fetching so many changes into single PR, I can split it if you want.

Also, I would recommend tagging package with tag `v0.0.1` or something similar to clarify used versions for everyone importing it into their go module.