### PR TITLE
Improvements to tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # go-graphite-client [![Build Status](https://travis-ci.org/jtaczanowski/go-graphite-client.png?branch=master)](https://travis-ci.org/jtaczanowski/go-graphite-client) [![Coverage Status](https://coveralls.io/repos/github/jtaczanowski/go-graphite-client/badge.svg?branch=master)](https://coveralls.io/github/jtaczanowski/go-graphite-client?branch=master)
+
 go-graphite-client - Simple Golang Graphite client which allows sending batches of metrics in single connection.
 
-The optimal use of the library is to collect all the metrics in ```map[string]float64``` and after that pass it to SendData() method. SendData() method creates new connection to Graphite server and pushes all metric in **single** connection.
+The optimal use of the library is to collect set of metrics for current minute in single ```map[string]float64```
+and after that pass it to `Client.SendData()` method.
+`Client.SendData()` method creates a new connection to Graphite server **every time it's called**
+and pushes all metric trough it.
 
-Example usage (also present in `example_text.go`)
+Example usage (taken from `example_text.go`)
 ```go
 package main
 
@@ -22,9 +26,21 @@ func Example() {
 		"test_metric2": 12345.12345,
 	}
 
-	// graphiteClient.SendData(data map[string]float64) error - this method receives a map of metrics as an argument
+	// append metrics from function which returns map[string]float64 as well
+	for k, v := range metricsGenerator() {
+		metricsMap[k] = v
+	}
+
+	// graphiteClient.SendData(data map[string]float64) error - this method expects a map of metrics as an argument
 	if err := graphiteClient.SendData(metricsMap); err != nil {
 		log.Printf("Error sending metrics: %v", err)
 	}
 }
+
+func metricsGenerator() map[string]float64 {
+	return map[string]float64{
+		"test_metric4": 3.14159265359,
+	}
+}
+
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -15,8 +15,19 @@ func Example() {
 		"test_metric2": 12345.12345,
 	}
 
-	// graphiteClient.SendData(data map[string]float64) error - this method receives a map of metrics as an argument
+	// append metrics from function which returns map[string]float64 as well
+	for k, v := range metricsGenerator() {
+		metricsMap[k] = v
+	}
+
+	// graphiteClient.SendData(data map[string]float64) error - this method expects a map of metrics as an argument
 	if err := graphiteClient.SendData(metricsMap); err != nil {
 		log.Printf("Error sending metrics: %v", err)
+	}
+}
+
+func metricsGenerator() map[string]float64 {
+	return map[string]float64{
+		"test_metric4": 3.14159265359,
 	}
 }

--- a/graphite.go
+++ b/graphite.go
@@ -10,12 +10,15 @@ import (
 
 var timeNow = time.Now
 
+const defaultTimeout = 3 * time.Second
+
 // Client - struct with Graphite connection settings
 type Client struct {
 	host     string
 	port     int
 	prefix   string
 	protocol string
+	timeOut  time.Duration
 }
 
 // NewClient - returns new Client
@@ -34,7 +37,10 @@ func NewClient(Host string, Port int, Prefix string, Protocol string) *Client {
 //   map[string]float64{"test": 1234.1234, "test": 1234.1234}
 func (g *Client) SendData(data map[string]float64) error {
 	dataToSent := g.prepareData(data)
-	conn, err := net.DialTimeout(g.protocol, g.host+":"+strconv.Itoa(g.port), time.Second*3)
+	if g.timeOut == 0 {
+		g.timeOut = defaultTimeout
+	}
+	conn, err := net.DialTimeout(g.protocol, g.host+":"+strconv.Itoa(g.port), g.timeOut)
 	if err != nil {
 		return err
 	}

--- a/graphite.go
+++ b/graphite.go
@@ -42,7 +42,6 @@ func NewClient(Host string, Port int, Prefix string, Protocol string) *Client {
 // float64 is metric value, example:
 //   map[string]float64{"test": 1234.1234, "test": 1234.1234}
 func (g *Client) SendData(data map[string]float64) error {
-	dataToSent := g.prepareData(data)
 	if g.timeOut == 0 {
 		g.timeOut = defaultTimeout
 	}
@@ -51,6 +50,7 @@ func (g *Client) SendData(data map[string]float64) error {
 		return err
 	}
 
+	dataToSent := g.prepareData(data)
 	for _, str := range dataToSent {
 		_, _ = conn.Write([]byte(str))
 	}

--- a/graphite.go
+++ b/graphite.go
@@ -12,7 +12,7 @@ var timeNow = time.Now
 
 const defaultTimeout = 3 * time.Second
 
-// Client - struct with Graphite connection settings
+// Client - struct with Graphite connection settings.
 type Client struct {
 	host     string
 	port     int
@@ -21,19 +21,20 @@ type Client struct {
 	timeOut  time.Duration
 }
 
-// NewClient - returns new Client
+// NewClient - returns new Client with default connection timeout set to 3s.
 func NewClient(Host string, Port int, Prefix string, Protocol string) *Client {
 	return &Client{
 		host:     Host,
 		port:     Port,
 		prefix:   Prefix,
 		protocol: Protocol,
+		timeOut:  defaultTimeout,
 	}
 }
 
-// SendData - creates new connection to Graphite server and
-// pushes provided batch of metrics in this single connection.
-// Default connect timeout is set to 3s.
+// SendData - creates new connection to Graphite server and pushes
+// provided batch of metrics in this single connection, thread-safe.
+//
 // Returns error in case of problems establishing or closing the connection
 // but no error in case of problems sending data trough the connection
 // (which should not be a problem with such short-lived connections).
@@ -42,9 +43,6 @@ func NewClient(Host string, Port int, Prefix string, Protocol string) *Client {
 // float64 is metric value, example:
 //   map[string]float64{"test": 1234.1234, "test": 1234.1234}
 func (g *Client) SendData(data map[string]float64) error {
-	if g.timeOut == 0 {
-		g.timeOut = defaultTimeout
-	}
 	conn, err := net.DialTimeout(g.protocol, g.host+":"+strconv.Itoa(g.port), g.timeOut)
 	if err != nil {
 		return err

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -1,7 +1,9 @@
 package graphite
 
 import (
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"testing"
 	"time"
@@ -16,13 +18,15 @@ func init() {
 
 // Below init function
 func TestSentMetricsOverTCP(t *testing.T) {
-	exceptedMessage := "prefix.test 1234.123400 1548015620\nprefix.test2 12345.123450 1548015620\n"
+	expected1 := "prefix.test 1234.123400 1548015620\n"
+	expected2 := "prefix.test2 12345.123450 1548015620\n"
 	receivedMessage := make(chan string, 1)
 	serverStarted := make(chan string, 1)
+	port := rand.Intn(40000) + 10000
 
 	go func() {
 		// start tcp server
-		listener, err := net.Listen("tcp", "127.0.0.1:2003")
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -45,27 +49,31 @@ func TestSentMetricsOverTCP(t *testing.T) {
 	<-serverStarted
 
 	// create graphite client and sent metrics in separate gorutine
-	graphiteClient := NewClient("127.0.0.1", 2003, "prefix", "tcp")
+	graphiteClient := NewClient("127.0.0.1", port, "prefix", "tcp")
 	metricsMap := map[string]float64{
 		"test":  1234.1234,
 		"test2": 12345.12345,
 	}
-	graphiteClient.SendData(metricsMap)
+	err := graphiteClient.SendData(metricsMap)
 
-	if msg := <-receivedMessage; msg != exceptedMessage {
-		t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, exceptedMessage)
+	if msg := <-receivedMessage; msg != expected1+expected2 && msg != expected2+expected1 {
+		t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, expected1+expected2)
+	}
+
+	if err != nil {
+		t.Fatalf("Unexpected error sending metrics:\nGot:\t\t%s\nExpected:\tnil\n", err)
 	}
 }
 
 func TestSentMetricsOverUDP(t *testing.T) {
-	exceptedMessage1 := "prefix.test 1234.123400 1548015620\n"
-	exceptedMessage2 := "prefix.test2 12345.123450 1548015620\n"
+	expectedMessages := []string{"prefix.test 1234.123400 1548015620\n", "prefix.test2 12345.123450 1548015620\n"}
 	receivedMessage := make(chan string, 2)
 	serverStarted := make(chan string, 1)
+	port := rand.Intn(40000) + 10000
 
 	go func() {
 		// start UDP server
-		listener, err := net.ListenPacket("udp", "127.0.0.1:2003")
+		listener, err := net.ListenPacket("udp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,17 +91,36 @@ func TestSentMetricsOverUDP(t *testing.T) {
 	<-serverStarted
 
 	// create graphite Client and sent two metrics
-	graphiteClient := NewClient("127.0.0.1", 2003, "prefix", "udp")
+	graphiteClient := NewClient("127.0.0.1", port, "prefix", "udp")
 	metricsMap := map[string]float64{
 		"test":  1234.1234,
 		"test2": 12345.12345,
 	}
-	graphiteClient.SendData(metricsMap)
+	err := graphiteClient.SendData(metricsMap)
 
-	if msg := <-receivedMessage; msg != exceptedMessage1 {
-		t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, exceptedMessage1)
+	for i := 1; i <= 2; i++ {
+		msg := <-receivedMessage
+		found := false
+		for _, n := range expectedMessages {
+			if n == msg {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, expectedMessages)
+		}
 	}
-	if msg := <-receivedMessage; msg != exceptedMessage2 {
-		t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, exceptedMessage2)
+	if err != nil {
+		t.Fatalf("Unexpected error sending metrics:\nGot:\t\t%s\nExpected:\tnil\n", err)
+	}
+}
+
+func TestSendFailure(t *testing.T) {
+	// create bad graphite Client, expects error establishing connection
+	graphiteClient := NewClient("bad_host", -1, "", "")
+	err := graphiteClient.SendData(map[string]float64{})
+
+	if err == nil {
+		t.Fatal("Unexpected error sending metrics:\nGot:\t\tnil\nExpected:\tnot-nil\n")
 	}
 }


### PR DESCRIPTION
* make tests 100% reliable - before `go test -count 100 ./...` was either stuck or found errors right away because of non-deterministic messages order.
* clarify readme and example on how metrics send and how to merge metrics
* clarify default connection timeout passing in the code
* clarify SendData function documentation and return error on `conn.Close()`
* don't prepare `dataToSent` if we don't have an established connection
